### PR TITLE
Enable manual stryker run without args

### DIFF
--- a/.github/workflows/SimplifiedSearch-ci.yml
+++ b/.github/workflows/SimplifiedSearch-ci.yml
@@ -44,13 +44,13 @@ jobs:
 
     - name: Stryker main
       if: github.ref == 'refs/heads/main'
-      run: dotnet stryker --version "${{ github.ref_name }}"
+      run: dotnet stryker --version "${{ github.ref_name }}" --reporter Dashboard
       env:
         STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
 
     - name: Stryker branch
       if: github.ref != 'refs/heads/main'
-      run: dotnet stryker --since:main --version "${{ github.ref_name }}"
+      run: dotnet stryker --since:main --version "${{ github.ref_name }}" --reporter Dashboard
       env:
         STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
 

--- a/stryker-config.json
+++ b/stryker-config.json
@@ -9,7 +9,8 @@
             "break": 90
         },
         "reporters": [
-            "dashboard"
+            "Dots",
+            "ClearText"
         ],
         "project-info": { 
             "name": "github.com/tommysor/SimplifiedSearch"


### PR DESCRIPTION
Can now do manual run by running `dotnet stryker`
Previously had to specify reporters since the default was the ci reporter (dashboard)