### PR TITLE
Prioritize hits closer in length

### DIFF
--- a/src/SimplifiedSearch/SearchPipelines/SimilarityRankPipelines/Components/MainSimilarityRanker.cs
+++ b/src/SimplifiedSearch/SearchPipelines/SimilarityRankPipelines/Components/MainSimilarityRanker.cs
@@ -27,19 +27,31 @@ namespace SimplifiedSearch.SearchPipelines.SimilarityRankPipelines.Components
         {
             // Shorten fieldValue to match start of word.
             // Add char to get better match when searchTerm is missing a character.
+            var bonusForFewTruncated = 0.5;
             var maxLength = searchTerm.Length + 1;
             if (fieldValue.Length > maxLength)
+            {
+                var truncatedCharCount = fieldValue.Length - maxLength;
+                bonusForFewTruncated = truncatedCharCount switch
+                {
+                    1 => .4,
+                    2 => .3,
+                    < 5 => .2,
+                    _ => 0
+                };
+
                 fieldValue = fieldValue.Substring(0, maxLength);
+            }
 
             var distance = Fastenshtein.Levenshtein.Distance(fieldValue, searchTerm);
             switch (distance)
             {
                 case 0:
-                    return 5;
+                    return 5.0 + bonusForFewTruncated;
                 case 1:
-                    return 3;
+                    return 3.0 + bonusForFewTruncated;
                 case 2:
-                    return 1;
+                    return 1.0 + bonusForFewTruncated;
             }
 
             return 0;

--- a/src/SimplifiedSearch/SearchPipelines/SimilarityRankPipelines/Components/MainSimilarityRanker.cs
+++ b/src/SimplifiedSearch/SearchPipelines/SimilarityRankPipelines/Components/MainSimilarityRanker.cs
@@ -27,34 +27,28 @@ namespace SimplifiedSearch.SearchPipelines.SimilarityRankPipelines.Components
         {
             // Shorten fieldValue to match start of word.
             // Add char to get better match when searchTerm is missing a character.
-            var bonusForFewTruncated = 0.5;
+            double truncatedCharCount = 0;
             var maxLength = searchTerm.Length + 1;
             if (fieldValue.Length > maxLength)
             {
-                var truncatedCharCount = fieldValue.Length - maxLength;
-                bonusForFewTruncated = truncatedCharCount switch
-                {
-                    1 => .4,
-                    2 => .3,
-                    < 5 => .2,
-                    _ => 0
-                };
-
+                truncatedCharCount = fieldValue.Length - maxLength;
                 fieldValue = fieldValue.Substring(0, maxLength);
             }
 
             var distance = Fastenshtein.Levenshtein.Distance(fieldValue, searchTerm);
-            switch (distance)
+            double distanceScore = distance switch
             {
-                case 0:
-                    return 5.0 + bonusForFewTruncated;
-                case 1:
-                    return 3.0 + bonusForFewTruncated;
-                case 2:
-                    return 1.0 + bonusForFewTruncated;
+                0 => 5,
+                1 => 3,
+                2 => 1,
+                _ => 0,
+            };
+            distanceScore -= truncatedCharCount / 10;
+            if (distanceScore < 0)
+            {
+                distanceScore = 0;
             }
-
-            return 0;
+            return distanceScore;
         }
     }
 }

--- a/tests/SimplifiedSearch.Tests/AcceptanceTests/ReasonableResultTests.cs
+++ b/tests/SimplifiedSearch.Tests/AcceptanceTests/ReasonableResultTests.cs
@@ -17,6 +17,21 @@ namespace SimplifiedSearch.Tests.AcceptanceTests
             _sut = new SimplifiedSearchFactory().Create();
         }
 
+        [Fact]
+        public async Task MatchShort_PrioritizedOverEqualMatchOnLonger()
+        {
+            string[] list = [
+                "Guiseppe Reynolds Emmettshire",
+                "Emma Smith Quigleyfort",
+            ];
+
+            var actual = await _sut.SimplifiedSearchAsync(list, "emm");
+            Assert.Collection(actual,
+                a => Assert.Equal("Emma Smith Quigleyfort", a),
+                b => Assert.Equal("Guiseppe Reynolds Emmettshire", b)
+            );
+        }
+
         [Theory]
         [InlineData("thaiwan", "Taiwan", "Thailand")]
         [InlineData("Niger", "Niger", "Nigeria")]

--- a/tests/SimplifiedSearch.Tests/AcceptanceTests/ReasonableResultTests.cs
+++ b/tests/SimplifiedSearch.Tests/AcceptanceTests/ReasonableResultTests.cs
@@ -17,21 +17,6 @@ namespace SimplifiedSearch.Tests.AcceptanceTests
             _sut = new SimplifiedSearchFactory().Create();
         }
 
-        [Fact]
-        public async Task MatchShort_PrioritizedOverEqualMatchOnLonger()
-        {
-            string[] list = [
-                "Guiseppe Reynolds Emmettshire",
-                "Emma Smith Quigleyfort",
-            ];
-
-            var actual = await _sut.SimplifiedSearchAsync(list, "emm");
-            Assert.Collection(actual,
-                a => Assert.Equal("Emma Smith Quigleyfort", a),
-                b => Assert.Equal("Guiseppe Reynolds Emmettshire", b)
-            );
-        }
-
         [Theory]
         [InlineData("thaiwan", "Taiwan", "Thailand")]
         [InlineData("Niger", "Niger", "Nigeria")]
@@ -95,6 +80,21 @@ namespace SimplifiedSearch.Tests.AcceptanceTests
             Assert.Collection(actual,
                 a => Assert.Equal(comment2, a),
                 b => Assert.Equal(comment1, b));
+        }
+
+        [Fact]
+        public async Task MatchShort_PrioritizedOverEqualMatchOnLonger()
+        {
+            string[] list = [
+                "Emmettshire",
+                "Emma",
+            ];
+
+            var actual = await _sut.SimplifiedSearchAsync(list, "emm");
+            Assert.Collection(actual,
+                a => Assert.Equal("Emma", a),
+                b => Assert.Equal("Emmettshire", b)
+            );
         }
 
         [Fact]


### PR DESCRIPTION
When matching the start of a word, a shorter word should be considered a better match than a long word when the start of the words match equally well